### PR TITLE
Block constructor should be able to silently accept another Block object

### DIFF
--- a/cgen/__init__.py
+++ b/cgen/__init__.py
@@ -852,6 +852,8 @@ class FunctionBody(Generable):
 
 class Block(Generable):
     def __init__(self, contents=[]):
+        if(isinstance(contents, Block)):
+            contents = contents.contents
         self.contents = contents[:]
 
         for item in contents:


### PR DESCRIPTION
If the Block constructor is passed another Block object as the argument, it should be able to silently initialise itself to the same contents as the passed object. 
This would help better decoupling of functions where they can either return an array of Statements, or a single Block object. Both will be treated the same by cgen. 