### PR TITLE
Add default args to Define and make elselines optional in IfNdef/Ifdef

### DIFF
--- a/cgen/__init__.py
+++ b/cgen/__init__.py
@@ -784,7 +784,7 @@ def make_multiple_ifs(conditions_and_blocks, base=None):
 # {{{ simple statements
 
 class Define(Generable):
-    def __init__(self, symbol, value):
+    def __init__(self, symbol, value=""):
         self.symbol = symbol
         self.value = value
 
@@ -1096,12 +1096,15 @@ class IfDef(Module):
     :param iflines: the block of code inside the if [an array of type Generable]
     :param elselines: the block of code inside the else [an array of type Generable]
     """
-    def __init__(self, condition, iflines, elselines):
+    def __init__(self, condition, iflines, elselines=None):
         ifdef_line = Line('#ifdef %s' % condition)
-        if len(elselines):
-            elselines.insert(0, Line('#else'))
-        endif_line = Line('#endif')
-        lines = [ifdef_line]+iflines+elselines+[endif_line]
+        lines = [ifdef_line] + iflines
+
+        if elselines:
+            lines += [Line('#else')]
+            lines += elselines
+
+        lines += [Line('#endif')]
         super(IfDef, self).__init__(lines)
 
     mapper_method = "map_ifdef"
@@ -1115,11 +1118,15 @@ class IfNDef(Module):
         [an array of type Generable]
     :param elselines: the block of code inside the else [an array of type Generable]
     """
-    def __init__(self, condition, ifndeflines, elselines):
+    def __init__(self, condition, ifndeflines, elselines=None):
         ifndefdef_line = Line('#ifndef %s' % condition)
-        if len(elselines):
-            elselines.insert(0, Line('#else'))
-        lines = [ifndefdef_line]+ifndeflines+elselines+[Line('#endif')]
+        lines = [ifndefdef_line] + ifndeflines
+
+        if elselines:
+            lines += [Line('#else')]
+            lines += elselines
+
+        lines += [Line('#endif')]
         super(IfNDef, self).__init__(lines)
 
     mapper_method = "map_ifndef"

--- a/test/test_cgen.py
+++ b/test/test_cgen.py
@@ -3,7 +3,7 @@ import sys
 from cgen import (
         POD, Struct, FunctionBody, FunctionDeclaration,
         For, If, Assign, Value, Block, ArrayOf, Comment,
-        Template, Pointer)
+        Template, Pointer, IfNDef, IfDef, Define)
 import numpy as np
 
 
@@ -56,6 +56,55 @@ def test_ptr_to_array():
 
     t2 = Pointer(Pointer(ArrayOf(POD(np.float32, "yyy"), 2)))
     assert str(t2) == "float **(yyy[2]);"
+
+def test_ifndef_no_else():
+    expected = """#ifndef SOME_DEFINE
+/* TRUE */
+#endif"""
+
+    code = IfNDef("SOME_DEFINE", [Comment("TRUE")])
+    assert str(code) == expected
+
+def test_ifndef():
+    expected = """#ifndef SOME_DEFINE
+/* TRUE */
+#else
+/* FALSE */
+#endif"""
+
+    code = IfNDef("SOME_DEFINE", [Comment("TRUE")], [Comment("FALSE")])
+    assert str(code) == expected
+
+def test_ifdef_no_else():
+    expected = """#ifdef SOME_DEFINE
+/* TRUE */
+#endif"""
+
+    code = IfDef("SOME_DEFINE", [Comment("TRUE")])
+    assert str(code) == expected
+
+def test_ifdef():
+    expected = """#ifdef SOME_DEFINE
+/* TRUE */
+#else
+/* FALSE */
+#endif"""
+
+    code = IfDef("SOME_DEFINE", [Comment("TRUE")], [Comment("FALSE")])
+    assert str(code) == expected
+
+
+def test_define_no_val():
+    expected = "#define SOME_DEFINE"
+    code = Define("SOME_DEFINE")
+    assert str(code) == expected
+
+
+def test_define_with_val():
+    expected = "#define SOME_DEFINE 42"
+    code = Define("SOME_DEFINE", 42)
+    assert str(code) == expected
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some quality of life improvements. This allows you to write a common include guard pattern such as:

```Python
test = c.IfNDef('__HEADER__', 
	[
		c.Define('__HEADER__'), 
		c.Comment("Header content")
	])

print(test)

```

Which results in:
```C
#ifndef __HEADER__
#define __HEADER__
/* Header content */
#endif
```

Also added some test for the new ifndef/ifdef functionality. 