### PR TITLE
Drop autodoc_typehints from sphinx config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,9 +49,7 @@ pygments_style = "sphinx"
 
 html_theme = "furo"
 
-
 autoclass_content = "class"
-autodoc_typehints = "description"
 
 intersphinx_mapping = {
         "https://docs.python.org/3/": None,


### PR DESCRIPTION
https://github.com/inducer/modepy/pull/38#issuecomment-846472970